### PR TITLE
Migrate to con_mix_foldable

### DIFF
--- a/data/json/itemgroups/tools.json
+++ b/data/json/itemgroups/tools.json
@@ -78,7 +78,7 @@
     "items": [
       { "item": "brick_kiln", "prob": 80, "charges": [ 0, 1000 ] },
       { "item": "kiln", "prob": 40 },
-      { "item": "con_mix", "prob": 120 },
+      { "item": "con_mix_foldable", "prob": 120 },
       { "item": "elec_jackhammer", "prob": 40, "charges": [ 0, 6600 ] },
       { "item": "reciprocating_saw", "prob": 80, "charges": [ 0, 500 ] },
       { "item": "cordless_impact_wrench", "prob": 20, "charges": [ 0, 500 ] },

--- a/data/json/items/tool/workshop.json
+++ b/data/json/items/tool/workshop.json
@@ -245,7 +245,7 @@
     "//2": "Based on https://www.amazon.com/dp/B000A24RCA"
   },
   {
-    "id": "con_mix",
+    "id": "con_mix_foldable",
     "type": "TOOL",
     "name": { "str": "concrete mixer" },
     "description": "A portable concrete mixer.  It is large and heavy, but it can be operated solo.  Unfold to use.",

--- a/data/json/mapgen/construction_site.json
+++ b/data/json/mapgen/construction_site.json
@@ -33,7 +33,7 @@
         "                        "
       ],
       "palettes": [ "construction_site_palette" ],
-      "place_loot": [ { "item": "con_mix", "x": [ 0, 8 ], "y": [ 5, 7 ] } ],
+      "place_loot": [ { "item": "con_mix_foldable", "x": [ 0, 8 ], "y": [ 5, 7 ] } ],
       "place_vehicles": [ { "vehicle": "small_utility_vehicles", "x": 12, "y": 4, "chance": 70, "rotation": 180 } ]
     }
   },
@@ -71,7 +71,7 @@
         "                        "
       ],
       "palettes": [ "construction_site_palette" ],
-      "place_loot": [ { "item": "con_mix", "x": [ 5, 9 ], "y": [ 4, 7 ] } ],
+      "place_loot": [ { "item": "con_mix_foldable", "x": [ 5, 9 ], "y": [ 4, 7 ] } ],
       "place_vehicles": [ { "vehicle": "small_utility_vehicles", "x": 12, "y": 4, "chance": 70, "rotation": 0 } ]
     }
   },
@@ -109,7 +109,7 @@
         "   c            ss      "
       ],
       "palettes": [ "construction_site_palette" ],
-      "place_loot": [ { "item": "con_mix", "x": [ 0, 4 ], "y": [ 17, 19 ] } ],
+      "place_loot": [ { "item": "con_mix_foldable", "x": [ 0, 4 ], "y": [ 17, 19 ] } ],
       "place_vehicles": [
         { "vehicle": "small_utility_vehicles", "x": 22, "y": 4, "chance": 66, "rotation": 270 },
         { "vehicle": "small_utility_vehicles", "x": 12, "y": 21, "chance": 66, "rotation": 180 }
@@ -150,7 +150,7 @@
         "   --  --  --  --  --   "
       ],
       "palettes": [ "construction_site_palette" ],
-      "place_loot": [ { "item": "con_mix", "x": [ 0, 17 ], "y": 1 } ],
+      "place_loot": [ { "item": "con_mix_foldable", "x": [ 0, 17 ], "y": 1 } ],
       "place_vehicles": [ { "vehicle": "small_utility_vehicles", "x": 20, "y": [ 6, 11 ], "chance": 70, "rotation": 270 } ]
     }
   },
@@ -188,7 +188,7 @@
         " c c                    "
       ],
       "palettes": [ "construction_site_palette" ],
-      "place_loot": [ { "item": "con_mix", "x": [ 5, 11 ], "y": [ 20, 23 ] } ],
+      "place_loot": [ { "item": "con_mix_foldable", "x": [ 5, 11 ], "y": [ 20, 23 ] } ],
       "place_vehicles": [ { "vehicle": "small_utility_vehicles", "x": 15, "y": 21, "chance": 70, "rotation": 180 } ]
     }
   }

--- a/data/json/mapgen/house/house_vacant.json
+++ b/data/json/mapgen/house/house_vacant.json
@@ -34,7 +34,7 @@
         "   --  --  --  --  --   "
       ],
       "palettes": [ "construction_site_palette" ],
-      "place_loot": [ { "item": "con_mix", "x": [ 12, 22 ], "y": [ 19, 22 ] } ],
+      "place_loot": [ { "item": "con_mix_foldable", "x": [ 12, 22 ], "y": [ 19, 22 ] } ],
       "place_vehicles": [ { "vehicle": "small_utility_vehicles", "x": 11, "y": 2, "chance": 70, "rotation": 0 } ]
     }
   },
@@ -73,7 +73,7 @@
         "   @@  sss   11 22 22   "
       ],
       "palettes": [ "construction_site_palette" ],
-      "place_loot": [ { "item": "con_mix", "x": [ 1, 9 ], "y": [ 16, 19 ] } ],
+      "place_loot": [ { "item": "con_mix_foldable", "x": [ 1, 9 ], "y": [ 16, 19 ] } ],
       "place_vehicles": [ { "vehicle": "small_utility_vehicles", "x": 20, "y": 2, "chance": 70, "rotation": 0 } ]
     }
   },
@@ -112,7 +112,7 @@
         " ss      --   --        "
       ],
       "palettes": [ "construction_site_palette" ],
-      "place_loot": [ { "item": "con_mix", "x": [ 2, 8 ], "y": [ 19, 21 ] } ],
+      "place_loot": [ { "item": "con_mix_foldable", "x": [ 2, 8 ], "y": [ 19, 21 ] } ],
       "place_vehicles": [ { "vehicle": "small_utility_vehicles", "x": 5, "y": 2, "chance": 70, "rotation": 0 } ]
     }
   },
@@ -151,7 +151,7 @@
         "                        "
       ],
       "palettes": [ "construction_site_palette" ],
-      "place_loot": [ { "item": "con_mix", "x": [ 7, 13 ], "y": [ 1, 5 ] } ],
+      "place_loot": [ { "item": "con_mix_foldable", "x": [ 7, 13 ], "y": [ 1, 5 ] } ],
       "place_vehicles": [ { "vehicle": "small_utility_vehicles", "x": 4, "y": 4, "chance": 70, "rotation": 90 } ]
     }
   }

--- a/data/json/npcs/NC_JUNK_SHOPKEEP.json
+++ b/data/json/npcs/NC_JUNK_SHOPKEEP.json
@@ -243,7 +243,7 @@
       { "item": "polisher", "prob": 20 },
       { "item": "screwdriver", "prob": 40 },
       { "item": "hammer", "prob": 35 },
-      { "item": "con_mix", "prob": 10 },
+      { "item": "con_mix_foldable", "prob": 10 },
       { "item": "brick_kiln", "prob": 10 },
       { "item": "kiln", "prob": 4 },
       { "item": "g_shovel", "prob": 20 },

--- a/data/json/obsoletion_and_migration_0.I/migration_items.json
+++ b/data/json/obsoletion_and_migration_0.I/migration_items.json
@@ -1141,5 +1141,11 @@
     "id": "ak74",
     "type": "MIGRATION",
     "replace": "ak74_semi"
+  },
+  {
+    "id": "con_mix",
+    "type": "MIGRATION",
+    "replace": "con_mix_foldable",
+    "reset_item_vars": true
   }
 ]

--- a/data/json/recipes/recipe_others.json
+++ b/data/json/recipes/recipe_others.json
@@ -1536,7 +1536,7 @@
   {
     "type": "recipe",
     "activity_level": "BRISK_EXERCISE",
-    "result": "con_mix",
+    "result": "con_mix_foldable",
     "category": "CC_OTHER",
     "subcategory": "CSC_OTHER_TOOLS",
     "skill_used": "fabrication",


### PR DESCRIPTION
We need to migrate the item definition so that we can apply  "reset_item_vars": true, otherwise the  concrete mixer item  will lack foldable vehicle data which results in crash on activation.